### PR TITLE
mask bad pixels in reference

### DIFF
--- a/src/musepsf/musepsf.py
+++ b/src/musepsf/musepsf.py
@@ -152,8 +152,8 @@ class MUSEImage(Image):
             plot_images(self.data, reference.data, 'MUSE', 'Reference', outname,
                         save=save, show=show)
 
-        # I need to know where the image is zero to erode it before minimization
-        zeromask = self.data == 0
+        # I need to know where the image is zero or NaN to erode it before minimization
+        zeromask = (self.data == 0) | (~np.isfinite(self.data))
 
         # rescaling the flux
         self.check_flux_calibration(reference.data, plot=plot, save=save, show=show)


### PR DESCRIPTION
(1) Masking bad pixels (NaN) in the reference image so that they don't become near-zero numbers after the automatic interpolation in convolution. Now, these bad pixels do not enter the calculation of the residual (and its minimisation). 

The key step of the implementation is no longer doing "nan_to_num" at the Image Class initialisation. A few other corresponding updates are done to keep the whole workflow (backward-)compatible and robust.

Specifically, the bad pixel region is enlarged by 2.0" to account for the affected neighbouring pixels (affected during convolution).

Attached figures show the effect of such masking (with and without).

(2) Outputting star counts at different stages (preparatory for exploration of Gaia star masking).

(3) Code for simple RMS clipping as additional star mask. (Commented out, not implemented.)

![NGC1068_IMAGE_FOV_P003_WFI_BB_final-fixed](https://github.com/user-attachments/assets/728f06d3-2720-4567-8931-efb66f3f3a07)
![NGC1068_IMAGE_FOV_P003_WFI_BB_final-ori](https://github.com/user-attachments/assets/57104b55-0760-4227-bccb-46c43078667e)

